### PR TITLE
use sass_processor inside Python code

### DIFF
--- a/sass_mwe/admin.py
+++ b/sass_mwe/admin.py
@@ -1,0 +1,3 @@
+from sass_processor.processor import sass_processor
+
+sass_processor('style.scss')


### PR DESCRIPTION
Now we get nearer to the problem.

We actually use `sass_processor` quite a lot inside Python code, especially in the Django admins. In you demo, you only use `sass_src` in the templates.

After applying this PR, `./manage.py compilescss` will not work anymore.